### PR TITLE
used generateStaticParams to build blog pages for SEO Optimization

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,11 +8,16 @@ import { wisp } from "@/lib/wisp";
 import { notFound } from "next/navigation";
 import type { BlogPosting, WithContext } from "schema-dts";
 
-export async function generateMetadata({
-  params: { slug },
-}: {
-  params: Params;
-}) {
+export async function generateStaticParams() {
+  // Get all Posts from Wisp so we build Blog Pages during build-time instead of request time
+  // SEO Optimization
+  const results = await wisp.getPosts();
+  return results.posts.map((post) => ({
+    slug: post.slug,
+  }));
+}
+
+export async function generateMetadata({ params: { slug } }: { params: Params }) {
   const result = await wisp.getPost(slug);
   if (!result || !result.post) {
     return {
@@ -58,10 +63,7 @@ const Page = async ({ params: { slug } }: { params: Params }) => {
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <div className="container mx-auto px-5">
         <Header />
         <BlogPostContent post={result.post} />


### PR DESCRIPTION
stumbled upon the Wisp CMS and used it on my own blog. One addition I did was build the Blog Pages at build time instead of request time and wanted to contribute the same strategy here if the community finds it beneficial. Provides a few benefits:

- Inline with Next.js best-practices (using Server Components where possible)
- Generates Static Pages 
- Better for SEO (your blog pages can now be indexed)
- removes the building of blog pages at request time

Before:

<img width="406" alt="Screenshot 2024-08-31 at 12 29 10 PM" src="https://github.com/user-attachments/assets/e735a5df-a423-417a-a112-5eb1bc610d62">

After:

<img width="391" alt="Screenshot 2024-08-31 at 12 28 26 PM" src="https://github.com/user-attachments/assets/dac472cc-1d88-44f1-a577-72f35c47b65d">

